### PR TITLE
Chromium browser support (ubuntu)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,7 +12,7 @@ function activate (context) {
     } else if (platform === 'darwin') {  // OS X
       quickPick = ['google chrome', 'firefox']
     } else {  // Linux
-      quickPick = ['google-chrome', 'firefox']
+      quickPick = ['chromium-browser', 'google-chrome', 'firefox']
     }
     vscode.window.showQuickPick(quickPick, { placeHolder: 'Which browser?' }).then((val) => {
       if (val) {


### PR DESCRIPTION
Chromium is the default browser on Ubuntu linux, so it could so helpful if the extension support that browser because open with default application is not working on ubuntu.